### PR TITLE
Remove unused members from GraphiteReporter.

### DIFF
--- a/src/cppmetrics/graphite/graphite_reporter.h
+++ b/src/cppmetrics/graphite/graphite_reporter.h
@@ -87,8 +87,6 @@ private:
     core::MetricRegistryPtr registry_;
     GraphiteSenderPtr sender_;
     std::string prefix_;
-    boost::chrono::milliseconds rate_unit_;
-    boost::chrono::milliseconds duration_unit_;
 };
 
 } /* namespace graphite */


### PR DESCRIPTION
The build was failing when using Clang 7 due to unused members
in `GraphiteReporter` and `-Wall,-Werror` being configured in
`CMakeLists.txt`. Example output:

```
...
[ 87%] Building CXX object CMakeFiles/cppmetrics.dir/src/cppmetrics/graphite/graphite_reporter.o
[ 93%] Building CXX object CMakeFiles/cppmetrics.dir/src/cppmetrics/core/console_reporter.o
In file included from ./src/cppmetrics/graphite/graphite_reporter.cpp:20:
./src/cppmetrics/graphite/graphite_reporter.h:90:33: error: private field 'rate_unit_' is not used [-Werror,-Wunused-private-field]
    boost::chrono::milliseconds rate_unit_;
                                ^
./src/cppmetrics/graphite/graphite_reporter.h:91:33: error: private field 'duration_unit_' is not used [-Werror,-Wunused-private-field]
    boost::chrono::milliseconds duration_unit_;
                                ^
2 errors generated.
```