### PR TITLE
Added ScheduledReporter::stopNow() to shut down immediately...

### DIFF
--- a/src/cppmetrics/concurrent/simple_scheduled_thread_pool_executor.cpp
+++ b/src/cppmetrics/concurrent/simple_scheduled_thread_pool_executor.cpp
@@ -65,7 +65,6 @@ void SimpleScheduledThreadPoolExecutor::cancelTimers() {
 void SimpleScheduledThreadPoolExecutor::timerHandler(
         const boost::system::error_code& ec, size_t timer_index) {
     if (!running_) {
-        LOG(ERROR)<< "Timer not started.";
         return;
     }
 

--- a/src/cppmetrics/core/scheduled_reporter.cpp
+++ b/src/cppmetrics/core/scheduled_reporter.cpp
@@ -63,6 +63,13 @@ void ScheduledReporter::stop() {
     }
 }
 
+void ScheduledReporter::stopNow() {
+    if (running_) {
+        running_ = false;
+        scheduled_executor_.shutdownNow();
+    }
+}
+
 std::string ScheduledReporter::rateUnitInSec() const {
     std::ostringstream ostrstr;
     ostrstr << rate_factor_;

--- a/src/cppmetrics/core/scheduled_reporter.h
+++ b/src/cppmetrics/core/scheduled_reporter.h
@@ -62,6 +62,12 @@ public:
      */
     virtual void stop();
 
+    /**
+     * Shuts down the background thread that polls/publishes the metrics from the registry, without
+     * waiting for pending tasks to complete.
+     */
+    virtual void stopNow();
+
 protected:
 
     /**


### PR DESCRIPTION
... without waiting for the next timer interval. This is necessary, for example, when shutting down in response to a signal. Also removed "Timer not started" message because that was printed unconditionally by the ConsoleReporter, regardless of whether the timer was started or not.